### PR TITLE
Adds support for entering regex categories.

### DIFF
--- a/import_tool/storage_config.json
+++ b/import_tool/storage_config.json
@@ -9,6 +9,6 @@
   },
   "categories": {
     "rel_path": "categories.csv",
-    "columns": ["transaction_description", "display_name", "category"]
+    "columns": ["transaction_description", "display_name", "category", "is_regex"]
   }
 }

--- a/moneyflow/categories_lib.py
+++ b/moneyflow/categories_lib.py
@@ -1,5 +1,6 @@
 """Library of objects to access transaction categories."""
 
+import ast
 import re
 import storage_lib
 
@@ -181,7 +182,7 @@ class Category(object):
   def fromdict(cls, row):
     return cls(
         row["transaction_description"], row["display_name"], row["category"],
-        bool(row["is_regex"]))
+        row["is_regex"].lower() == 'true')
 
   def tolist(self):
     return [self.transaction_description, self.display_name, self.category,

--- a/moneyflow/categories_lib.py
+++ b/moneyflow/categories_lib.py
@@ -24,6 +24,10 @@ class CategoriesTable(storage_lib.ObjectStorage):
     Should be called after reading/adding categories to the table, but before
     calling GetCategoryForTransaction. If the table's contents are changed,
     this method must be called again before further lookups.
+
+    TOOD(murthykk): Do this on instantiation to make this class RAII. If
+    there's a method to add categories to an existing table instance,
+    add new map entries at the end of the method.
     """
     self._description_map = {
       cat.transaction_description: idx for idx,cat in enumerate(self.objects)
@@ -58,27 +62,51 @@ class CategoriesTable(storage_lib.ObjectStorage):
 class Category(object):
   """Container for category data."""
 
+  # TODO: The transaction descrioption can just be a regex match. Shoiuld compile it as a Python regex first to see if it works.
+  # If not, then just use exact match.
+  #
+  # The tricky bit will be: what happens when multiple categories match a single transaction? This hasn't happened 
+  # previously since the description_map unique-ifies the associated transaction description, and the descriptions need to 
+  # match exactly. This will essentially end up matching a transaction to the first category. We could continue this but it's
+  # more dangerous with regex, as something like (*) can match everything. It would be worth warning if a transaction 
+  # matches to more than one category.
+  #
+  # Actually, the issue with regex is that they can't be applied using the fast hashing lookup that currently 
+  # matches categories. So, regex have to be tracked separately.
   transaction_description = ""
   display_name = ""
   category = ""
+
+  is_regex = False
+  """True if the transaction_description is a regex instead of an exact match."""
+
+  # Required for all storage objects. This should be in a superclass.
   is_new = False
 
-  def __init__(self, transaction_description, display_name, category):
+  def __init__(self, transaction_description, display_name, category, is_regex=False):
     if not isinstance(transaction_description, str):
       raise ValueError("Argument 'transaction_description' must be a string.")
     if not isinstance(display_name, str):
       raise ValueError("Argument 'display_name' must be a string.")
     if not isinstance(category, str):
       raise ValueError("Argument 'category' must be a string.")
+    if not isinstance(is_regex, bool):
+      # is_regex could be None, and in this case, assume that the description isn't a regex.
+      if is_regex is None:
+        is_regex = False
+      else:
+        raise ValueError("Argument 'is_regex' must be a bool or None.")
     self.transaction_description = transaction_description
     self.display_name = display_name
     self.category = category
+    self.is_regex = is_regex
 
   def todict(self):
     return {
         "transaction_description": self.transaction_description,
         "display_name": self.display_name,
         "category": self.category
+        "is_regex": self.is_regex
     }
 
   def to_native_dict(self):
@@ -87,11 +115,11 @@ class Category(object):
   @classmethod
   def fromdict(cls, row):
     return cls(
-        row["transaction_description"], row["display_name"], row["category"])
+        row["transaction_description"], row["display_name"], row["category"], row["is_regex"])
 
   def tolist(self):
-    return [self.transaction_description, self.display_name, self.category]
+    return [self.transaction_description, self.display_name, self.category, self.is_regex]
 
   @classmethod
-  def getlistheadings(cls, transaction_description, display_name, category):
-    return [transaction_description, display_name, category]
+  def getlistheadings(cls, transaction_description, display_name, category, is_regex):
+    return [transaction_description, display_name, category, is_regex]

--- a/moneyflow/categories_lib.py
+++ b/moneyflow/categories_lib.py
@@ -150,7 +150,7 @@ class Category(object):
   is_new = False
 
   def __init__(self, transaction_description, display_name, category, is_regex=None):
-    if not isinstance(transaction_description, str):
+    if not isinstance(transaction_description, basestring):
       raise ValueError("Argument 'transaction_description' must be a string.")
     if not isinstance(display_name, str):
       raise ValueError("Argument 'display_name' must be a string.")

--- a/moneyflow/categories_lib.py
+++ b/moneyflow/categories_lib.py
@@ -9,7 +9,7 @@ class CategoriesTable(storage_lib.ObjectStorage):
   def __init__(self):
     super(CategoriesTable, self).__init__(
         "categories", Category,
-        ["Transaction Description", "Display Name", "Category"])
+        ["Transaction Description", "Display Name", "Category", "Regex?"])
     self._description_map = None
 
   def GetSortedCategoryNames(self):
@@ -105,7 +105,7 @@ class Category(object):
     return {
         "transaction_description": self.transaction_description,
         "display_name": self.display_name,
-        "category": self.category
+        "category": self.category,
         "is_regex": self.is_regex
     }
 

--- a/moneyflow/categories_lib_test.py
+++ b/moneyflow/categories_lib_test.py
@@ -15,7 +15,7 @@ class CategoriesTableTest(absltest.TestCase):
   def setUp(self):
     self._fake_storage = test_utils.FakeStorageTable(
         "cateogories",
-        ["transaction_description", "display_name", "category"])
+        ["transaction_description", "display_name", "category", "is_regex"])
     mock.patch.object(
         categories_lib.storage_lib, "GetStorageTable",
         return_value=self._fake_storage).start()
@@ -26,9 +26,10 @@ class CategoriesTableTest(absltest.TestCase):
     test_description = "This is some transaction"
     test_display_name = "AwesomeTransaction"
     test_category = "Goodness"
+    test_is_regex = True
 
     cat = categories_lib.Category(
-        test_description, test_display_name, test_category)
+        test_description, test_display_name, test_category, test_is_regex)
     self._categories.Add(cat)
     self._categories.Save()
 
@@ -36,6 +37,7 @@ class CategoriesTableTest(absltest.TestCase):
     self.assertEqual(test_description, row["transaction_description"])
     self.assertEqual(test_display_name, row["display_name"])
     self.assertEqual(test_category, row["category"])
+    self.assertEqual(test_is_regex, row["is_regex"])
 
   def testPrint(self):
     test_description = "This is a printed transaction"
@@ -45,6 +47,8 @@ class CategoriesTableTest(absltest.TestCase):
         categories_lib.Category(
             test_description, test_display_name, test_category))
     self._categories.Print()
+
+  # TODO: update tests below for regex searching
 
   def testGetCategoryForTransaction(self):
     test_description = "This transaction should be found"

--- a/moneyflow/storage_lib.py
+++ b/moneyflow/storage_lib.py
@@ -44,6 +44,8 @@ def GetStorageTable(table_name):
 # TODO: Unit test this class and remove subclass unit tests.
 # TODO: Make an object base class and make it clear what subclasses need to
 # implement.
+# TODO: Avoid having to load the underlying CSV data every time a new
+# ObjectStorage subclass is instantiated.
 class ObjectStorage(object):
   """Accesses deserialized objects from a storage backend.
 

--- a/moneyflow/storage_lib.py
+++ b/moneyflow/storage_lib.py
@@ -52,6 +52,12 @@ class ObjectStorage(object):
     fromdict
     tolist
     getlistheadings
+
+  The construction of this object is backed by a StorageTable containing
+  the ability to access serialized objects. Use ObjectStorage.ReadAll() to
+  deserialize the data in the storage table. Use the Add() and Save() methods
+  to add new objects to the storage table and serialize/save the new objects to
+  disk.
   """
 
   _objects = deque()

--- a/moneyflow/ui_utils.py
+++ b/moneyflow/ui_utils.py
@@ -220,14 +220,14 @@ def PrintTransactionCategories(
         txn["transaction_description"],
         txn["transaction_amount"],
         cat_dict["category"]
-      ] + [get_regex_col(cat)] if print_regex_col else []
+      ] + ([get_regex_col(cat)] if print_regex_col else [])
     else:
       return [
         txn["transaction_date"],
         txn["transaction_description"],
         txn["transaction_amount"],
         "None"
-      ] + ["None"] if print_regex_col else []
+      ] + (["None"] if print_regex_col else [])
 
   table_headings = [
       "Index", "Date", "Description", "Amount", "Category"

--- a/moneyflow/ui_utils.py
+++ b/moneyflow/ui_utils.py
@@ -165,7 +165,7 @@ def _PrintRegexCategoryInfo(re_cat, transactions_table, categories_table):
   # matching transaction.
   matching_transaction_cats = deque()
 
-  regex = categories_lib.CompileRegex(re_cat.transaction_description)
+  regex = categories_lib.CompiledRegex(re_cat.transaction_description)
   for transaction in transactions_table.objects:
     if categories_lib.MatchRegexObj(regex, transaction.description):
       matching_transactions.append(transaction)

--- a/moneyflow/ui_utils.py
+++ b/moneyflow/ui_utils.py
@@ -120,9 +120,10 @@ def AddCategoriesToTransactions(cat_table, transactions):
           # add the new ones passed into this function.
           if transactions_table is None:
             transactions_table = transactions_lib.TransactionsTable()
-            transactions_table.ReadAll(overwrite=True)
+            all_transactions = set(transactions_table.ReadAll(overwrite=True))
             for txn in transactions:
-              transactions_table.Add(txn)
+              if txn not in all_transactions:
+                transactions_table.Add(txn)
           _PrintRegexCategoryInfo(cat, transactions_table, cat_table)
       except ValueError as e:
         print("Invalid input. Problem: %s" % str(e))

--- a/moneyflow/ui_utils_test.py
+++ b/moneyflow/ui_utils_test.py
@@ -1,5 +1,6 @@
 """Tests for ui_utils.py."""
 
+import copy
 import datetime
 import categories_lib
 import mock
@@ -42,9 +43,34 @@ class UserInputTests(absltest.TestCase):
     cat = ui_utils._GetCategoryFromUser(transaction_desc)
     self.assertEqual("test cat", cat.category)
     self.assertEqual("disp name", cat.display_name)
+    self.assertFalse(cat.is_regex)
     self.assertEqual(transaction_desc, cat.transaction_description)
 
-  # TODO: add regex cat unit tests, includinig success and fail where NOne is returned.
+  @mock.patch("__builtin__.raw_input",
+              side_effect=["test trans", "test cat", "disp name"])
+  @mock.patch("ui_utils.PromptUser", return_value=True)  # Accept regex cat.
+  def testGetRegexCategoryFromUser(self, unused1, unused2):
+    """Tests that a valid regex category is returned by _GetCategoryFromUser."""
+    transaction_desc = "test trans desc"
+    cat = ui_utils._GetCategoryFromUser(transaction_desc)
+    self.assertEqual("test cat", cat.category)
+    self.assertEqual("disp name", cat.display_name)
+    self.assertTrue(cat.is_regex)
+    self.assertEqual("test trans", cat.transaction_description)
+
+  @mock.patch("__builtin__.raw_input",
+              side_effect=["invalid regex", "another invalid regex"])
+  @mock.patch("ui_utils.PromptUser", side_effect=[
+      True,  # Yes to regex entry.
+      True,  # Yes to try again when first entry fails.
+      False  # No to try again after second entry fails.
+  ])
+  def testGetRegexCategoryFromUser(self, unused1, unused2):
+    """Tests that an invalid regex category returns None."""
+    transaction_desc = "test trans desc"
+    cat = ui_utils._GetCategoryFromUser(transaction_desc)
+    self.assertIsNone(cat)
+
 
 
 class CategorizationTests(absltest.TestCase):
@@ -126,7 +152,79 @@ class CategorizationTests(absltest.TestCase):
     # Make sure the right category information was added.
     self.assertDictEqual(new_cat.todict(), added_cat.todict())
 
-  # TODO: add a test where _GetCategoryFromUser returns None.
+  @mock.patch("ui_utils.GetIntegerFromUser", return_value=1)
+  @mock.patch("ui_utils.PromptUser", side_effect=[
+      True,  # Yes to "Add a category?"
+      True,  # Yes to "Add this category?"
+      False  # No to second "Add a category?"
+  ])
+  def testAddCategoriesToTransactions_AddRegexCategory(self, unused1, unused2):
+    """Tests the adding of a regex category."""
+    cat_table = categories_lib.CategoriesTable()
+    self._AddStandardCategoriesToTable(cat_table)
+
+    # Add a couple of uncategorized transactions to the standard ones.
+    transactions = copy.deepcopy(self.STANDARD_TRANSACTIONS)
+    new_txn1 = transactions_lib.Transaction(
+        7, datetime.date(2015, 4, 21), "uncategorized desc", -3.38)
+    transactions += [new_txn1]
+    new_txn2 = transactions_lib.Transaction(
+        7, datetime.date(2015, 3, 22), "uncategorized desc 1", -9.27)
+    transactions += [new_txn2]
+
+    # Add a category that matches the second of the above transactions.
+    exact_match_cat = categories_lib.Category(
+        "uncategorized desc 1", "UNCAT", "EXISTING CAT", is_regex=False)
+    cat_table.Add(exact_match_cat)
+
+    # The following regex category will be added, which should match both of the
+    # above new categories. Note that the user will be warned that the category
+    # that was just added in the line above already matches a transaction.
+    regex_cat = categories_lib.Category(
+        "uncategorized", "new disp", "new_cat", is_regex=True)
+
+    with mock.patch("ui_utils._GetCategoryFromUser", return_value=regex_cat):
+      self.assertTrue(
+          ui_utils.AddCategoriesToTransactions(cat_table, transactions))
+
+    # Make sure the expected number of new categories was added.
+    self.assertEqual(
+        len(self.STANDARD_CATEGORIES) + 2, len(cat_table),
+        "The expected new categories were not added to the category table.")
+
+    # Find the categories for the new transactions.
+    cat_table.InitializeCategoryLookup()
+    matching_cat1 = cat_table.GetCategoryForTransaction(new_txn1)
+    matching_cat2 = cat_table.GetCategoryForTransaction(new_txn2)
+    self.assertIsNotNone(matching_cat1)
+    self.assertIsNotNone(matching_cat2)
+
+    # Make sure the right category information was added. Note that the first
+    # transaction should match the regex, but the second transaction should
+    # match exactly the newly added category, which takes precedence over the
+    # regex.
+    self.assertDictEqual(regex_cat.todict(), matching_cat1.todict())
+    self.assertDictEqual(exact_match_cat.todict(), matching_cat2.todict())
+
+  @mock.patch("ui_utils.GetIntegerFromUser", return_value=1)
+  @mock.patch("ui_utils.PromptUser", side_effect=[
+      True,  # Yes to "Add a category?"
+      False  # No to second "Add a category?"
+  ])
+  def testAddCategoriesToTransactions_UserCancelsCategoryInput(
+      self, unused1, unused2):
+    """Tests that a category can be added."""
+    cat_table = categories_lib.CategoriesTable()
+    self._AddStandardCategoriesToTable(cat_table)
+
+    # Add an uncategorized transaction to the standard ones.
+    new_txn = transactions_lib.Transaction(
+        7, datetime.date(2013, 1, 25), "uncategorized desc", -48.49)
+    transactions = self.STANDARD_TRANSACTIONS + [new_txn]
+
+    with mock.patch("ui_utils._GetCategoryFromUser", return_value=None):
+      self.assertFalse(
+          ui_utils.AddCategoriesToTransactions(cat_table, transactions))
 
   @mock.patch("ui_utils.PromptUser", return_value=False)
   def testAddCategoriesToTransactions_NotEverythingCategorized(self, unused):

--- a/moneyflow/ui_utils_test.py
+++ b/moneyflow/ui_utils_test.py
@@ -36,12 +36,15 @@ class UserInputTests(absltest.TestCase):
       ui_utils.GetIntegerFromUser("get int", 1, 5)
 
   @mock.patch("__builtin__.raw_input", side_effect=["test cat", "disp name"])
-  def testGetCategoryFromUser(self, unused):
+  @mock.patch("ui_utils.PromptUser", return_value=False)  # Decline regex cat.
+  def testGetCategoryFromUser(self, unused1, unused2):
     transaction_desc = "test trans desc"
-    cat = ui_utils.GetCategoryFromUser(transaction_desc)
+    cat = ui_utils._GetCategoryFromUser(transaction_desc)
     self.assertEqual("test cat", cat.category)
     self.assertEqual("disp name", cat.display_name)
     self.assertEqual(transaction_desc, cat.transaction_description)
+
+  # TODO: add regex cat unit tests, includinig success and fail where NOne is returned.
 
 
 class CategorizationTests(absltest.TestCase):
@@ -103,7 +106,7 @@ class CategorizationTests(absltest.TestCase):
     new_cat = categories_lib.Category(
             "uncategorized desc", "new disp", "new_cat")
 
-    with mock.patch("ui_utils.GetCategoryFromUser", return_value=new_cat):
+    with mock.patch("ui_utils._GetCategoryFromUser", return_value=new_cat):
       self.assertTrue(
           ui_utils.AddCategoriesToTransactions(cat_table, transactions))
 
@@ -122,6 +125,8 @@ class CategorizationTests(absltest.TestCase):
 
     # Make sure the right category information was added.
     self.assertDictEqual(new_cat.todict(), added_cat.todict())
+
+  # TODO: add a test where _GetCategoryFromUser returns None.
 
   @mock.patch("ui_utils.PromptUser", return_value=False)
   def testAddCategoriesToTransactions_NotEverythingCategorized(self, unused):


### PR DESCRIPTION
When adding a new category, a Python regex can be entered in order to match the single category entry to multiple transaction descriptions. However, exact matches to categories still take precedence over regex matches.

Fixes #1 